### PR TITLE
update: keypad migration to gpiozero (kernel 6.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.12.3
+
+- fix(keypad): make keypad compatible with kernel 6.6 by using gpiozero
+
 ## Version 0.12.2
 
 - feat(lightdm): add lightdm service

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Note that as part of the installation process, these debian packages are install
 - libgl1
 - libmtdev1
 - libzbar0
-- python3
-- python3-dev
-- python3-libcamera
 - python3-alsaaudio
+- python3-dev
+- python3-gpiozero
+- python3-libcamera
 - python3-picamera2
 - python3-pip
 - python3-pyaudio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ubo-app"
-version = "0.12.2"
+version = "0.12.3"
 description = "Ubo main app, running on device initialization. A platform for running other apps."
 authors = ["Sassan Haradji <sassanh@gmail.com>"]
 license = "Apache-2.0"

--- a/ubo_app/services/020-keypad/setup.py
+++ b/ubo_app/services/020-keypad/setup.py
@@ -167,13 +167,12 @@ class Keypad:
     def init_i2c(self: Keypad) -> None:
         if not IS_RPI:
             return
-        # connect to the I2C bus
-        from RPi import GPIO
+        # Use GPIO to receive interrupt from the GPIO expander
+        from gpiozero import Button
 
-        GPIO.setmode(GPIO.BCM)
         i2c = board.I2C()
         # Set this to the GPIO of the interrupt:
-        GPIO.setup(INT_EXPANDER, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+        btn = Button(INT_EXPANDER)
         try:
             import adafruit_aw9523
 
@@ -207,13 +206,8 @@ class Keypad:
         self.event_queue = [Event(inputs=self.inputs, timestamp=time.time())]
         time.sleep(0.5)
 
-        # Enable interrupt on the GPIO expander
-        GPIO.add_event_detect(
-            INT_EXPANDER,
-            GPIO.FALLING,
-            callback=self.key_press_cb,
-            bouncetime=1,
-        )
+        # Interrupt callback when any button is pressed
+        btn.when_pressed=self.key_press_cb
 
     def key_press_cb(self: Keypad, _: object) -> None:
         """Handle key press dispatched by GPIO interrupt.

--- a/ubo_app/system/install.sh
+++ b/ubo_app/system/install.sh
@@ -80,9 +80,10 @@ apt-get -y install \
   libgl1 \
   libmtdev1 \
   libzbar0 \
-  python3-dev \
-  python3-libcamera \
   python3-alsaaudio \
+  python3-dev \
+  python3-gpiozero \
+  python3-libcamera \
   python3-picamera2 \
   python3-pip \
   python3-pyaudio \


### PR DESCRIPTION
This should address keypad issue on kernel 6.6. Following package should be installed beforehand:

```
sudo apt install python3-gpiozero
```